### PR TITLE
Koopa sprite, spawn in and player interaction

### DIFF
--- a/Flamario2Unity/Assets/Scenes/Main.unity
+++ b/Flamario2Unity/Assets/Scenes/Main.unity
@@ -1213,6 +1213,7 @@ GameObject:
   m_Component:
   - component: {fileID: 39271175}
   - component: {fileID: 39271174}
+  - component: {fileID: 39271176}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -1246,6 +1247,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &39271176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39271173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4c583fb1c5915e40b42bfb0b75187cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mario: {fileID: 1974411146}
+  koopa: {fileID: 83659707}
 --- !u!1001 &39513341
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2380,6 +2395,155 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1289966144}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &83659707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 83659709}
+  - component: {fileID: 83659708}
+  - component: {fileID: 83659710}
+  - component: {fileID: 83659711}
+  - component: {fileID: 83659712}
+  m_Layer: 0
+  m_Name: Koopa
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!212 &83659708
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83659707}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 7ad8d03be7c2c47d7ab886bf9c3747c1, type: 3}
+  m_Color: {r: 0.34705818, g: 0.7924528, b: 0.33268064, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &83659709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83659707}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.28, y: 1.11, z: 1.1072887}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &83659710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83659707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91205ebe93a204f448c1e50c8fc75f10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  collisionLayer:
+    serializedVersion: 2
+    m_Bits: 512
+  speed: 2
+  spritesArray:
+  - {fileID: 0}
+  - {fileID: 0}
+  koopaRb: {fileID: 83659711}
+--- !u!50 &83659711
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83659707}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &83659712
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 83659707}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!4 &84619691 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 126127908838619458, guid: 14a7e963d95e94ac3913517f3bfff76e,
@@ -55176,6 +55340,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2910648304024487388, guid: 04c66d3a4e11c4dfe8754816ad271bba,
+        type: 3}
+      propertyPath: m_TagString
+      value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 2910648304024487384, guid: 04c66d3a4e11c4dfe8754816ad271bba,
         type: 3}

--- a/Flamario2Unity/Assets/Scripts/EnemyManager.cs
+++ b/Flamario2Unity/Assets/Scripts/EnemyManager.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyManager : MonoBehaviour
+{
+    [SerializeField]
+    private GameObject mario;
+    [SerializeField]
+    private GameObject koopa;
+    private Transform marioTransform;
+    private bool koopaActivated = false;
+
+    void Start()
+    {
+        marioTransform = mario.GetComponent<Transform>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        //At the moment Koopa is spawned in the section where mario is, after 
+        //Mario steps forward a little
+        if (marioTransform.position.x > 2 && koopaActivated == false)
+        {
+            koopaActivated = true;
+            koopa.SetActive(true);
+        }
+    }
+}

--- a/Flamario2Unity/Assets/Scripts/EnemyManager.cs.meta
+++ b/Flamario2Unity/Assets/Scripts/EnemyManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4c583fb1c5915e40b42bfb0b75187cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Flamario2Unity/Assets/Scripts/KoopaController.cs
+++ b/Flamario2Unity/Assets/Scripts/KoopaController.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class KoopaController : MonoBehaviour
+{
+    [SerializeField] protected LayerMask collisionLayer;
+    [SerializeField] protected float speed = 5;
+    protected Vector2 dir;
+    enum KoopaState
+    {
+        Walking = 1,
+        InShell = 2,
+        Zooming = 3,
+    }
+
+    public Sprite[] spritesArray = new Sprite[2];
+    KoopaState state;
+    [SerializeField]
+    private Rigidbody2D koopaRb;
+
+    private void Start()
+    {
+        dir = Vector2.left;
+        state = KoopaState.Walking;
+    }
+    
+    private void Update()
+    {
+
+        switch (state)
+        {
+            case KoopaState.Walking:
+                Movement();
+                break;
+
+            case KoopaState.Zooming:
+                Movement();
+                break;
+        }
+        
+
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        
+
+        if (collision.gameObject.tag == "Player")
+        {
+            switch (state)
+            {
+                case KoopaState.Walking:
+                    /*
+                     * // Detects if Mario hits Koopa from the top
+                    Vector3 hit = collision.contacts[0].normal;
+                    float angle = Vector3.Angle(hit, Vector3.up);
+
+                    if (Mathf.Approximately(angle, 180))
+                    {
+                        state = KoopaState.InShell;
+                        Debug.Log("Hit on top");
+                    }
+                    */
+
+                    state = KoopaState.InShell; 
+                    Debug.Log("Hit" + state);
+
+                    break;
+
+                case KoopaState.InShell:
+                    state = KoopaState.Zooming;
+                    dir *= -1;
+                    speed = 10;
+                    break;
+            }
+        }
+    }
+
+    private void Movement()
+    {
+        if (IsColliding())
+        {
+            dir *= -1;
+        }
+        transform.position += new Vector3(dir.x * speed * Time.deltaTime, 0, 0);
+    }
+
+    private bool IsColliding()
+    {
+        Vector3 origin = transform.position;
+
+        RaycastHit2D hit = Physics2D.Raycast(origin, dir, transform.lossyScale.x / 2, collisionLayer);
+        //Debug.DrawRay(origin, dir * transform.lossyScale.x/2, Color.yellow);
+        return hit.collider != null;
+    }
+
+}

--- a/Flamario2Unity/Assets/Scripts/KoopaController.cs.meta
+++ b/Flamario2Unity/Assets/Scripts/KoopaController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91205ebe93a204f448c1e50c8fc75f10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Koops is spawned into the Section where Mario starts for the moment (since theres no jump). He only spawns after Mario steps forward a little. The Koopa has 3 states, walking, sitting still in his shell after being hit once, then a zooming mode once Mario hits him a again. For the moment any collision with Mario will count as a 'hit', but there is code there for detection a hit on the 'head' once Mario can jump!